### PR TITLE
Chris/develop

### DIFF
--- a/dist/implementation/onm-address-binder.js
+++ b/dist/implementation/onm-address-binder.js
@@ -195,7 +195,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             if (!((resolveActions_.setUniqueKey != null) && resolveActions_.setUniqueKey)) {
               throw new Error("You must define semanticBindings.setUniqueKey function in your data model declaration.");
             }
-            resolveActions_.setUniqueKey(newData);
+            resolveActions_.setUniqueKey(newData, key_);
             if (!((resolveActions_.getUniqueKey != null) && resolveActions_.getUniqueKey)) {
               throw new Error("You must define semanticBindings.getUniqueKey function in your data model declaration.");
             }

--- a/dist/implementation/onm-address-binder.js
+++ b/dist/implementation/onm-address-binder.js
@@ -115,8 +115,8 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
     }
   };
 
-  InitializeComponentNamespaces = function(store_, data_, descriptor_, extensionPointId_, key_) {
-    var childDescriptor, exception, resolveResults, _i, _len, _ref;
+  InitializeComponentNamespaces = function(store_, data_, descriptor_, extensionPointId_, key_, propertyAssignmentObject_) {
+    var childDescriptor, exception, propertyAssignmentObject, resolveResults, _i, _len, _ref;
     try {
       if (!((data_ != null) && data_)) {
         throw new Error("Missing data reference input parameter.");
@@ -131,8 +131,9 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         childDescriptor = _ref[_i];
         if (childDescriptor.namespaceType !== "component") {
-          resolveResults = ResolveNamespaceDescriptor({}, store_, data_, childDescriptor, key_, "new");
-          InitializeComponentNamespaces(store_, resolveResults.dataReference, childDescriptor, extensionPointId_, key_);
+          propertyAssignmentObject = (propertyAssignmentObject_ != null) && propertyAssignmentObject_ && (propertyAssignmentObject_[childDescriptor.jsonTag] != null) && propertyAssignmentObject_[childDescriptor.jsonTag] || {};
+          resolveResults = ResolveNamespaceDescriptor({}, store_, data_, childDescriptor, key_, "new", propertyAssignmentObject);
+          InitializeComponentNamespaces(store_, resolveResults.dataReference, childDescriptor, extensionPointId_, key_, propertyAssignmentObject);
         }
       }
       return true;
@@ -230,7 +231,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
 
   module.exports = AddressTokenBinder = (function() {
     function AddressTokenBinder(store_, parentDataReference_, token_, mode_, propertyAssignmentObject_) {
-      var descriptor, exception, extensionPointId, generations, getUniqueKeyFunction, model, parentPathIds, pathId, resolveActions, resolveResults, semanticBindings, setUniqueKeyFunction, targetComponentDescriptor, targetNamespaceDescriptor, _i, _len;
+      var descriptor, exception, extensionPointId, generations, getUniqueKeyFunction, model, parentPathIds, pathId, propertyAssignmentObject, resolveActions, resolveResults, semanticBindings, setUniqueKeyFunction, targetComponentDescriptor, targetNamespaceDescriptor, _i, _len;
       try {
         this.store = (store_ != null) && store_ || (function() {
           throw new Error("Missing object store input parameter.");
@@ -256,14 +257,15 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
           setUniqueKey: setUniqueKeyFunction,
           getUniqueKey: getUniqueKeyFunction
         };
-        resolveResults = ResolveNamespaceDescriptor(resolveActions, store_, this.parentDataReference, token_.componentDescriptor, token_.key, mode_);
+        propertyAssignmentObject = (propertyAssignmentObject_ != null) && propertyAssignmentObject_ || {};
+        resolveResults = ResolveNamespaceDescriptor(resolveActions, store_, this.parentDataReference, token_.componentDescriptor, token_.key, mode_, propertyAssignmentObject);
         this.dataReference = resolveResults.dataReference;
         if (resolveResults.created) {
           this.resolvedToken.key = resolveResults.key;
         }
         extensionPointId = (token_.extensionPointDescriptor != null) && token_.extensionPointDescriptor && token_.extensionPointDescriptor.id || -1;
         if (mode_ === "new" && resolveResults.created) {
-          InitializeComponentNamespaces(store_, this.dataReference, targetComponentDescriptor, extensionPointId, this.resolvedToken.key, propertyAssignmentObject_);
+          InitializeComponentNamespaces(store_, this.dataReference, targetComponentDescriptor, extensionPointId, this.resolvedToken.key, propertyAssignmentObject);
         }
         if (mode_ === "strict") {
           VerifyComponentNamespaces(store_, resolveResult.dataReference, targetComponentDescriptor, extensionPointId);

--- a/dist/implementation/onm-address-binder.js
+++ b/dist/implementation/onm-address-binder.js
@@ -36,8 +36,8 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
 (function() {
   var AddressTokenBinder, InitializeComponentNamespaces, InitializeNamespaceProperties, ResolveNamespaceDescriptor, VerifyComponentNamespaces, VerifyNamespaceProperties;
 
-  InitializeNamespaceProperties = function(data_, descriptor_) {
-    var exception, functions, memberName, _ref, _ref1;
+  InitializeNamespaceProperties = function(data_, descriptor_, propertyAssignmentObject_) {
+    var exception, functions, memberName, propertyAssignmentObject, _ref, _ref1;
     try {
       if (!((data_ != null) && data_)) {
         throw new Error("Missing data reference input parameter.");
@@ -45,11 +45,14 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
       if (!((descriptor_ != null) && descriptor_)) {
         throw new Error("Missing descriptor input parameter.");
       }
+      propertyAssignmentObject = (propertyAssignmentObject_ != null) && propertyAssignmentObject_ || {};
       if ((descriptor_.userImmutable != null) && descriptor_.userImmutable) {
         _ref = descriptor_.userImmutable;
         for (memberName in _ref) {
           functions = _ref[memberName];
-          if ((functions.fnCreate != null) && functions.fnCreate) {
+          if ((propertyAssignmentObject[memberName] != null) && propertyAssignmentObject[memberName]) {
+            data_[memberName] = propertyAssignmentObject[memberName];
+          } else if ((functions.fnCreate != null) && functions.fnCreate) {
             data_[memberName] = functions.fnCreate();
           } else {
             data_[memberName] = functions.defaultValue;
@@ -60,7 +63,9 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
         _ref1 = descriptor_.userMutable;
         for (memberName in _ref1) {
           functions = _ref1[memberName];
-          if ((functions.fnCreate != null) && functions.fnCreate) {
+          if ((propertyAssignmentObject[memberName] != null) && propertyAssignmentObject[memberName]) {
+            data_[memberName] = propertyAssignmentObject[memberName];
+          } else if ((functions.fnCreate != null) && functions.fnCreate) {
             data_[memberName] = functions.fnCreate();
           } else {
             data_[memberName] = functions.defaultValue;
@@ -153,7 +158,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
     }
   };
 
-  ResolveNamespaceDescriptor = function(resolveActions_, store_, data_, descriptor_, key_, mode_) {
+  ResolveNamespaceDescriptor = function(resolveActions_, store_, data_, descriptor_, key_, mode_, propertyAssignmentObject_) {
     var exception, newData, resolveResults, tokenString;
     try {
       if (!((resolveActions_ != null) && resolveActions_)) {
@@ -190,7 +195,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             break;
           }
           newData = {};
-          InitializeNamespaceProperties(newData, descriptor_.namespaceModelPropertiesDeclaration);
+          InitializeNamespaceProperties(newData, descriptor_.namespaceModelPropertiesDeclaration, propertyAssignmentObject_);
           if (descriptor_.namespaceType === "component") {
             if (!((resolveActions_.setUniqueKey != null) && resolveActions_.setUniqueKey)) {
               throw new Error("You must define semanticBindings.setUniqueKey function in your data model declaration.");
@@ -224,7 +229,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
   };
 
   module.exports = AddressTokenBinder = (function() {
-    function AddressTokenBinder(store_, parentDataReference_, token_, mode_) {
+    function AddressTokenBinder(store_, parentDataReference_, token_, mode_, propertyAssignmentObject_) {
       var descriptor, exception, extensionPointId, generations, getUniqueKeyFunction, model, parentPathIds, pathId, resolveActions, resolveResults, semanticBindings, setUniqueKeyFunction, targetComponentDescriptor, targetNamespaceDescriptor, _i, _len;
       try {
         this.store = (store_ != null) && store_ || (function() {
@@ -258,7 +263,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
         }
         extensionPointId = (token_.extensionPointDescriptor != null) && token_.extensionPointDescriptor && token_.extensionPointDescriptor.id || -1;
         if (mode_ === "new" && resolveResults.created) {
-          InitializeComponentNamespaces(store_, this.dataReference, targetComponentDescriptor, extensionPointId, this.resolvedToken.key);
+          InitializeComponentNamespaces(store_, this.dataReference, targetComponentDescriptor, extensionPointId, this.resolvedToken.key, propertyAssignmentObject_);
         }
         if (mode_ === "strict") {
           VerifyComponentNamespaces(store_, resolveResult.dataReference, targetComponentDescriptor, extensionPointId);

--- a/dist/onm-model.js
+++ b/dist/onm-model.js
@@ -439,8 +439,8 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             this.semanticBindings.getUniqueKey = function(data_) {
               return data_.key;
             };
-            this.semanticBindings.setUniqueKey = function(data_) {
-              data_.key = "" + (LUID++);
+            this.semanticBindings.setUniqueKey = function(data_, key_) {
+              data_.key = (key_ != null) && key_ || ("" + (LUID++));
               return data_.key;
             };
             break;
@@ -448,8 +448,9 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             this.semanticBindings.getUniqueKey = function(data_) {
               return data_.key;
             };
-            this.semanticBindings.setUniqueKey = function(data_) {
-              return data_.key = uuid.v4();
+            this.semanticBindings.setUniqueKey = function(data_, key_) {
+              data_.key = (key_ != null) && key_ || uuid.v4();
+              return data_.key;
             };
             break;
           case "external":

--- a/dist/onm-namespace.js
+++ b/dist/onm-namespace.js
@@ -70,7 +70,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
   })();
 
   module.exports = Namespace = (function() {
-    function Namespace(store_, address_, mode_) {
+    function Namespace(store_, address_, mode_, keyArray_, propertyAssignmentObject_) {
       this.visitExtensionPointSubcomponents = __bind(this.visitExtensionPointSubcomponents, this);
       this.getExtensionPointSubcomponentCount = __bind(this.getExtensionPointSubcomponentCount, this);
       this.update = __bind(this.update, this);

--- a/dist/onm-namespace.js
+++ b/dist/onm-namespace.js
@@ -81,7 +81,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
       this.getResolvedLabel = __bind(this.getResolvedLabel, this);
       this.getComponentKey = __bind(this.getComponentKey, this);
       this.getResolvedAddress = __bind(this.getResolvedAddress, this);
-      var address, addressToken, componentAddress, exception, extensionPointAddress, extensionPointNamespace, mode, objectModel, objectModelNameKeys, objectModelNameStore, resolvedAddress, tokenBinder, _i, _len, _ref;
+      var address, addressToken, componentAddress, exception, extensionPointAddress, extensionPointNamespace, key, keyArrayCount, keyIndex, mode, objectModel, objectModelNameKeys, objectModelNameStore, resolvedAddress, tokenArrayCount, tokenBinder, tokenIndex, _i, _len, _ref;
       try {
         if (!((store_ != null) && store_)) {
           throw new Error("Missing object store input parameter.");
@@ -106,6 +106,21 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
         mode = (mode_ != null) && mode_ || "bypass";
         if ((mode !== "new") && !address.isResolvable()) {
           throw new Error("'" + mode + "' mode error: Unresolvable address '" + (address.getHumanReadableString()) + "' invalid for this operation.");
+        }
+        keyArrayCount = (keyArray_ != null) && keyArray_.length || 0;
+        if (keyArrayCount) {
+          tokenArrayCount = address.implementation.tokenVector.length;
+          if (keyArrayCount > (tokenArrayCount - 1)) {
+            throw new Error("Too many component keys specified in optional key array parameter for address '" + (address_.getHumanReadableString()) + "'.");
+          }
+          address = address.clone();
+          keyIndex = 0;
+          while (keyIndex < keyArrayCount) {
+            key = keyArray_[keyIndex];
+            tokenIndex = tokenArrayCount - keyArrayCount + keyIndex;
+            address.implementation.tokenVector[tokenIndex].key = key;
+            keyIndex++;
+          }
         }
         _ref = address.implementation.tokenVector;
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {

--- a/dist/onm-namespace.js
+++ b/dist/onm-namespace.js
@@ -81,7 +81,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
       this.getResolvedLabel = __bind(this.getResolvedLabel, this);
       this.getComponentKey = __bind(this.getComponentKey, this);
       this.getResolvedAddress = __bind(this.getResolvedAddress, this);
-      var address, addressToken, componentAddress, exception, extensionPointAddress, extensionPointNamespace, key, keyArrayCount, keyIndex, mode, objectModel, objectModelNameKeys, objectModelNameStore, resolvedAddress, tokenArrayCount, tokenBinder, tokenIndex, _i, _len, _ref;
+      var address, addressToken, componentAddress, constructionOptions, exception, extensionPointAddress, extensionPointNamespace, key, keyArrayCount, keyIndex, mode, objectModel, objectModelNameKeys, objectModelNameStore, resolvedAddress, tokenArrayCount, tokenBinder, tokenCount, tokenIndex, _i, _len, _ref;
       try {
         if (!((store_ != null) && store_)) {
           throw new Error("Missing object store input parameter.");
@@ -108,8 +108,8 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
           throw new Error("'" + mode + "' mode error: Unresolvable address '" + (address.getHumanReadableString()) + "' invalid for this operation.");
         }
         keyArrayCount = (keyArray_ != null) && keyArray_.length || 0;
+        tokenArrayCount = address.implementation.tokenVector.length;
         if (keyArrayCount) {
-          tokenArrayCount = address.implementation.tokenVector.length;
           if (keyArrayCount > (tokenArrayCount - 1)) {
             throw new Error("Too many component keys specified in optional key array parameter for address '" + (address_.getHumanReadableString()) + "'.");
           }
@@ -122,10 +122,12 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             keyIndex++;
           }
         }
+        tokenCount = 0;
         _ref = address.implementation.tokenVector;
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           addressToken = _ref[_i];
-          tokenBinder = new AddressTokenBinder(store_, this.implementation.dataReference, addressToken, mode);
+          constructionOptions = ((tokenArrayCount - 1) === tokenCount++) && propertyAssignmentObject_ || void 0;
+          tokenBinder = new AddressTokenBinder(store_, this.implementation.dataReference, addressToken, mode, constructionOptions);
           this.implementation.resolvedTokenArray.push(tokenBinder.resolvedToken);
           this.implementation.dataReference = tokenBinder.dataReference;
           if (mode === "new") {

--- a/dist/onm-store.js
+++ b/dist/onm-store.js
@@ -161,7 +161,9 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             if (dataExtensionPoint[sourceComponentKey] != null) {
               throw new Error("The specified component already exists in the target store.");
             }
-            return _this.createComponent(addressExtensionPoint_.createSubcomponentAddress());
+            dataExtensionPoint[sourceComponentKey] = jslib.clone(namespaceSource_.data());
+            _this.implementation.reifier.reifyStoreComponent(addressSource);
+            return _this.openNamespace(addressSource);
           } catch (_error) {
             exception = _error;
             throw new Error("injectComponent failure: " + exception.message);

--- a/dist/onm-store.js
+++ b/dist/onm-store.js
@@ -116,10 +116,10 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
           var componentNamespace, descriptor, exception;
           try {
             if (!((address_ != null) && address_)) {
-              throw new Error("Missing object model namespace selector input parameter.");
+              throw new Error("Missing address input parameter.");
             }
             if (!_this.validateAddressModel(address_)) {
-              throw new Error("The specified address cannot be used to reference this store because it's not bound to the same model as this store.");
+              throw new Error("Address/store data model mismatch. Can't use the specified address to access this store.");
             }
             if (address_.isQualified()) {
               throw new Error("The specified address is qualified and may only be used to specify existing objects in the store.");
@@ -138,6 +138,29 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             throw new Error("createComponent failure: " + exception.message);
           }
         };
+        this.injectComponent = function(addressExtensionPoint_, namespaceSource_) {
+          var descriptor, exception, namespaceExtensionPoint;
+          try {
+            if (!((addressExtensionPoint_ != null) && addressExtensionPoint_)) {
+              throw new Error("Missing address input parameter.");
+            }
+            if (!_this.validateAddressModel(addressExtensionPoint_)) {
+              throw new Error("Address/store data model mismatch. Can't use the specified address to access this store.");
+            }
+            if (!addressExtensionPoint_.isQualified()) {
+              throw new Error("The specified address is not qualified and cannot be used to specify a component injection point.");
+            }
+            descriptor = addressExtensionPoint_.implementation.getDescriptor();
+            if (!descriptor.namespaceType === "extensionPoint") {
+              throw new Error("The specified address does not refer to an extension point namespace.");
+            }
+            namespaceExtensionPoint = _this.openNamespace(addressExtensionPoint_);
+            return _this.createComponent(addressExtensionPoint_.createSubcomponentAddress());
+          } catch (_error) {
+            exception = _error;
+            throw new Error("injectComponent failure: " + exception.message);
+          }
+        };
         this.removeComponent = function(address_) {
           var componentDictionary, componentKey, componentNamespace, descriptor, exception, extensionPointAddress, extensionPointNamespace;
           try {
@@ -154,7 +177,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             if (!descriptor.isComponent) {
               throw new Error("The specified address does not specify the root of a component.");
             }
-            if (descriptor.namespace === "root") {
+            if (descriptor.namespaceType === "root") {
               throw new Error("The specified address refers to the root namespace of the store which cannot be removed.");
             }
             _this.implementation.reifier.reifyStoreExtensions(address_, void 0, true);

--- a/dist/onm-store.js
+++ b/dist/onm-store.js
@@ -112,7 +112,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             throw new Error("validateAddressModel failure: " + exception.message);
           }
         };
-        this.createComponent = function(address_) {
+        this.createComponent = function(address_, keyArray_, propertyAssignmentObject_) {
           var componentNamespace, descriptor, exception;
           try {
             if (!((address_ != null) && address_)) {
@@ -131,7 +131,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
             if (descriptor.namespaceType === "root") {
               throw new Error("The specified address refers to the root namespace of the store which is created automatically.");
             }
-            componentNamespace = new Namespace(_this, address_, "new");
+            componentNamespace = new Namespace(_this, address_, "new", keyArray_, propertyAssignmentObject_);
             return componentNamespace;
           } catch (_error) {
             exception = _error;

--- a/dist/onm-store.js
+++ b/dist/onm-store.js
@@ -139,7 +139,7 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
           }
         };
         this.injectComponent = function(addressExtensionPoint_, namespaceSource_) {
-          var descriptor, exception, namespaceExtensionPoint;
+          var addressSource, dataExtensionPoint, descriptor, exception, namespaceExtensionPoint, sourceComponentKey;
           try {
             if (!((addressExtensionPoint_ != null) && addressExtensionPoint_)) {
               throw new Error("Missing address input parameter.");
@@ -155,6 +155,12 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
               throw new Error("The specified address does not refer to an extension point namespace.");
             }
             namespaceExtensionPoint = _this.openNamespace(addressExtensionPoint_);
+            dataExtensionPoint = namespaceExtensionPoint.data();
+            sourceComponentKey = namespaceSource_.getComponentKey();
+            addressSource = namespaceSource_.getResolvedAddress();
+            if (dataExtensionPoint[sourceComponentKey] != null) {
+              throw new Error("The specified component already exists in the target store.");
+            }
             return _this.createComponent(addressExtensionPoint_.createSubcomponentAddress());
           } catch (_error) {
             exception = _error;

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "onm",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Object Namespace Manager (onm) data model, schema-driven JSON factory and in-memory subsystem communication bus for complex data-driven Node.js/HTML 5 client apps.",
   "keywords": [
+    "JSON",
     "object factory",
     "data model",
     "data",
-    "JSON",
     "design pattern",
     "model",
     "store",
@@ -16,6 +16,8 @@
     "signal",
     "visitor",
     "factory",
+    "bus",
+    "channel",
     "delegate",
     "proxy",
     "encapsule",

--- a/src/implementation/onm-address-binder.coffee
+++ b/src/implementation/onm-address-binder.coffee
@@ -41,20 +41,26 @@ BLOG: http://blog.encapsule.org TWITTER: https://twitter.com/Encapsule
 
 #
 # ****************************************************************************
-InitializeNamespaceProperties = (data_, descriptor_) ->
+InitializeNamespaceProperties = (data_, descriptor_, propertyAssignmentObject_) ->
     try
-        if not (data_? and data_) then throw new Error("Missing data reference input parameter.");
-        if not (descriptor_? and descriptor_) then throw new Error("Missing descriptor input parameter.");
+        if not (data_? and data_) then throw new Error("Missing data reference input parameter.")
+        if not (descriptor_? and descriptor_) then throw new Error("Missing descriptor input parameter.")
+
+        propertyAssignmentObject = propertyAssignmentObject_? and propertyAssignmentObject_ or {}
 
         if descriptor_.userImmutable? and descriptor_.userImmutable
             for memberName, functions of descriptor_.userImmutable
-                if functions.fnCreate? and functions.fnCreate
+                if propertyAssignmentObject[memberName]? and propertyAssignmentObject[memberName]
+                    data_[memberName] = propertyAssignmentObject[memberName]
+                else if functions.fnCreate? and functions.fnCreate
                     data_[memberName] = functions.fnCreate()
                 else
                     data_[memberName] = functions.defaultValue
         if descriptor_.userMutable? and descriptor_.userMutable
             for memberName, functions of descriptor_.userMutable
-                if functions.fnCreate? and functions.fnCreate
+                if propertyAssignmentObject[memberName]? and propertyAssignmentObject[memberName]
+                    data_[memberName] = propertyAssignmentObject[memberName]
+                else if functions.fnCreate? and functions.fnCreate
                     data_[memberName] = functions.fnCreate()
                 else
                     data_[memberName] = functions.defaultValue
@@ -123,7 +129,7 @@ VerifyComponentNamespaces = (store_, data_, descriptor_, extensionPointId_) ->
 
 #
 # ****************************************************************************
-ResolveNamespaceDescriptor = (resolveActions_, store_, data_, descriptor_, key_, mode_) ->
+ResolveNamespaceDescriptor = (resolveActions_, store_, data_, descriptor_, key_, mode_, propertyAssignmentObject_) ->
     try
 
         if not (resolveActions_? and resolveActions_) then throw new Error("Internal error: missing resolve actions structure input parameter.");
@@ -153,7 +159,7 @@ ResolveNamespaceDescriptor = (resolveActions_, store_, data_, descriptor_, key_,
                     break
 
                 newData = {}
-                InitializeNamespaceProperties(newData, descriptor_.namespaceModelPropertiesDeclaration)
+                InitializeNamespaceProperties(newData, descriptor_.namespaceModelPropertiesDeclaration, propertyAssignmentObject_)
 
                 if descriptor_.namespaceType == "component"
                     if not (resolveActions_.setUniqueKey? and resolveActions_.setUniqueKey)
@@ -193,7 +199,7 @@ ResolveNamespaceDescriptor = (resolveActions_, store_, data_, descriptor_, key_,
 #
 # ****************************************************************************
 module.exports = class AddressTokenBinder
-    constructor: (store_, parentDataReference_, token_, mode_) ->
+    constructor: (store_, parentDataReference_, token_, mode_, propertyAssignmentObject_) ->
         try
             @store = store_? and store_ or throw new Error("Missing object store input parameter.");
             model = store_.model
@@ -226,7 +232,7 @@ module.exports = class AddressTokenBinder
             extensionPointId = token_.extensionPointDescriptor? and token_.extensionPointDescriptor and token_.extensionPointDescriptor.id or -1
 
             if mode_ == "new" and resolveResults.created
-                InitializeComponentNamespaces(store_, @dataReference, targetComponentDescriptor, extensionPointId, @resolvedToken.key)
+                InitializeComponentNamespaces(store_, @dataReference, targetComponentDescriptor, extensionPointId, @resolvedToken.key, propertyAssignmentObject_)
 
             if mode_ == "strict"
                 VerifyComponentNamespaces(store_, resolveResult.dataReference, targetComponentDescriptor, extensionPointId)            

--- a/src/implementation/onm-address-binder.coffee
+++ b/src/implementation/onm-address-binder.coffee
@@ -158,10 +158,14 @@ ResolveNamespaceDescriptor = (resolveActions_, store_, data_, descriptor_, key_,
                 if descriptor_.namespaceType == "component"
                     if not (resolveActions_.setUniqueKey? and resolveActions_.setUniqueKey)
                         throw new Error("You must define semanticBindings.setUniqueKey function in your data model declaration.");
-                    resolveActions_.setUniqueKey(newData)
+
+                    resolveActions_.setUniqueKey(newData, key_)
+
                     if not (resolveActions_.getUniqueKey? and resolveActions_.getUniqueKey)
                         throw new Error("You must define semanticBindings.getUniqueKey function in your data model declaration.");
+
                     resolveResults.key = resolveResults.jsonTag = resolveActions_.getUniqueKey(newData)
+
                     if not (resolveResults.key? and resolveResults.key)
                         throw new Error("Your data model's semanticBindings.getUniqueKey function returned an invalid key. Key cannot be zero or zero-length.");
 

--- a/src/onm-model.coffee
+++ b/src/onm-model.coffee
@@ -476,13 +476,15 @@ class ModelDetails
                     break
                 when "internalLuid"
                     @semanticBindings.getUniqueKey = (data_) -> data_.key
-                    @semanticBindings.setUniqueKey = (data_) ->
-                        data_.key = "#{LUID++}"
+                    @semanticBindings.setUniqueKey = (data_, key_) ->
+                        data_.key = key_? and key_ or "#{LUID++}"
                         data_.key
                     break
                 when "internalUuid"
                     @semanticBindings.getUniqueKey = (data_) -> data_.key
-                    @semanticBindings.setUniqueKey = (data_) -> data_.key = uuid.v4()
+                    @semanticBindings.setUniqueKey = (data_, key_) ->
+                        data_.key = key_? and key_ or uuid.v4()
+                        data_.key
                     break
                 when "external"
                     break

--- a/src/onm-namespace.coffee
+++ b/src/onm-namespace.coffee
@@ -60,8 +60,12 @@ class NamespaceDetails
 #
 #
 # ****************************************************************************
+# optional parameters passed by onm.Store.createComponent (i.e. mode="new")
+# keyArray_ --- to be applied in order, tail-justified, to the component token vector key array
+# propertyAssignmentObject_ --- options object of property assignments to be cherry-picked and transcribed to newly-contructed components _prior_ to observer signal
+
 module.exports = class Namespace
-    constructor: (store_, address_, mode_) ->
+    constructor: (store_, address_, mode_, keyArray_, propertyAssignmentObject_) ->
         try
             if not (store_? and store_) then throw new Error("Missing object store input parameter.")
             @store = store_

--- a/src/onm-namespace.coffee
+++ b/src/onm-namespace.coffee
@@ -94,6 +94,31 @@ module.exports = class Namespace
             if (mode != "new") and not address.isResolvable()
                 throw new Error("'#{mode}' mode error: Unresolvable address '#{address.getHumanReadableString()}' invalid for this operation.")
 
+
+            # Let's try to do some address manipulation here based on the keyArray_ and propertyAssignmentObject_ params
+            #
+
+            keyArrayCount = keyArray_? and keyArray_.length or 0
+
+            if keyArrayCount
+
+                tokenArrayCount = address.implementation.tokenVector.length
+                if keyArrayCount > (tokenArrayCount - 1)
+                    throw new Error("Too many component keys specified in optional key array parameter for address '#{address_.getHumanReadableString()}'.");
+
+                # Clone the address
+                address = address.clone();
+
+                # Overwrite overlapping keys
+
+                keyIndex = 0
+                while keyIndex < keyArrayCount
+                    key = keyArray_[keyIndex]
+                    tokenIndex = tokenArrayCount - keyArrayCount + keyIndex
+                    address.implementation.tokenVector[tokenIndex].key = key
+                    keyIndex++
+
+
             # The actual store data.
 
             for addressToken in address.implementation.tokenVector

--- a/src/onm-namespace.coffee
+++ b/src/onm-namespace.coffee
@@ -99,18 +99,14 @@ module.exports = class Namespace
             #
 
             keyArrayCount = keyArray_? and keyArray_.length or 0
+            tokenArrayCount = address.implementation.tokenVector.length
 
             if keyArrayCount
-
-                tokenArrayCount = address.implementation.tokenVector.length
                 if keyArrayCount > (tokenArrayCount - 1)
                     throw new Error("Too many component keys specified in optional key array parameter for address '#{address_.getHumanReadableString()}'.");
-
                 # Clone the address
                 address = address.clone();
-
                 # Overwrite overlapping keys
-
                 keyIndex = 0
                 while keyIndex < keyArrayCount
                     key = keyArray_[keyIndex]
@@ -118,13 +114,14 @@ module.exports = class Namespace
                     address.implementation.tokenVector[tokenIndex].key = key
                     keyIndex++
 
-
             # The actual store data.
-
+            tokenCount = 0
             for addressToken in address.implementation.tokenVector
-                tokenBinder = new AddressTokenBinder(store_, @implementation.dataReference, addressToken, mode)
+                constructionOptions = ((tokenArrayCount - 1) == tokenCount++) and propertyAssignmentObject_ or undefined;
+                tokenBinder = new AddressTokenBinder(store_, @implementation.dataReference, addressToken, mode, constructionOptions)
                 @implementation.resolvedTokenArray.push tokenBinder.resolvedToken
                 @implementation.dataReference = tokenBinder.dataReference
+
                 if mode == "new"
                     if addressToken.idComponent 
                         if not (addressToken.key? and addressToken.key)

--- a/src/onm-store.coffee
+++ b/src/onm-store.coffee
@@ -133,7 +133,6 @@ module.exports = class Store
                     return componentNamespace
 
                 catch exception
-
                     throw new Error("createComponent failure: #{exception.message}");
 
 
@@ -158,9 +157,11 @@ module.exports = class Store
                     if dataExtensionPoint[sourceComponentKey]?
                         throw new Error("The specified component already exists in the target store.")
 
+                    dataExtensionPoint[sourceComponentKey] = jslib.clone(namespaceSource_.data())
+                    @implementation.reifier.reifyStoreComponent(addressSource);
 
-                    return @createComponent(addressExtensionPoint_.createSubcomponentAddress());
-
+                    @openNamespace(addressSource);
+                    
                 catch exception
                     throw new Error("injectComponent failure: #{exception.message}");
 

--- a/src/onm-store.coffee
+++ b/src/onm-store.coffee
@@ -121,8 +121,8 @@ module.exports = class Store
             # ============================================================================
             @createComponent = (address_) =>
                 try
-                    if not (address_? and address_) then throw new Error("Missing object model namespace selector input parameter.");
-                    if not @validateAddressModel(address_) then throw new Error("The specified address cannot be used to reference this store because it's not bound to the same model as this store.");
+                    if not (address_? and address_) then throw new Error("Missing address input parameter.");
+                    if not @validateAddressModel(address_) then throw new Error("Address/store data model mismatch. Can't use the specified address to access this store.");
                     if address_.isQualified() then throw new Error("The specified address is qualified and may only be used to specify existing objects in the store.");
                     descriptor = address_.implementation.getDescriptor()
                     if not descriptor.isComponent then throw new Error("The specified address does not specify the root of a component.");
@@ -136,6 +136,24 @@ module.exports = class Store
 
                     throw new Error("createComponent failure: #{exception.message}");
 
+
+            #
+            # ============================================================================
+            @injectComponent = (addressExtensionPoint_, namespaceSource_) =>
+                try
+                    if not (addressExtensionPoint_? and addressExtensionPoint_) then throw new Error("Missing address input parameter.");
+                    if not @validateAddressModel(addressExtensionPoint_) then throw new Error("Address/store data model mismatch. Can't use the specified address to access this store.");
+                    if not addressExtensionPoint_.isQualified() then throw new Error("The specified address is not qualified and cannot be used to specify a component injection point.");
+                    descriptor = addressExtensionPoint_.implementation.getDescriptor()
+                    if not descriptor.namespaceType == "extensionPoint" then throw new Error("The specified address does not refer to an extension point namespace.");
+
+                    namespaceExtensionPoint = @openNamespace(addressExtensionPoint_);
+
+                    return @createComponent(addressExtensionPoint_.createSubcomponentAddress());
+
+                catch exception
+                    throw new Error("injectComponent failure: #{exception.message}");
+
             #
             # ============================================================================
             @removeComponent = (address_) =>
@@ -145,7 +163,7 @@ module.exports = class Store
                     if not address_.isQualified() then throw new Error("You cannot use an unqualified address to remove a component.");
                     descriptor = address_.implementation.getDescriptor()
                     if not descriptor.isComponent then throw new Error("The specified address does not specify the root of a component.");
-                    if descriptor.namespace == "root" then throw new Error("The specified address refers to the root namespace of the store which cannot be removed.");
+                    if descriptor.namespaceType == "root" then throw new Error("The specified address refers to the root namespace of the store which cannot be removed.");
                     # Unrefify the component before actually making any modifications to the store.
                     # modelViewObserver_ == undefined -> broadcast to all registered observers
                     # undoFlag_ == true -> invert namespace traversal order and invoke remove callbacks

--- a/src/onm-store.coffee
+++ b/src/onm-store.coffee
@@ -147,7 +147,17 @@ module.exports = class Store
                     descriptor = addressExtensionPoint_.implementation.getDescriptor()
                     if not descriptor.namespaceType == "extensionPoint" then throw new Error("The specified address does not refer to an extension point namespace.");
 
-                    namespaceExtensionPoint = @openNamespace(addressExtensionPoint_);
+                    namespaceExtensionPoint = @openNamespace(addressExtensionPoint_)
+                    dataExtensionPoint = namespaceExtensionPoint.data()
+
+                    sourceComponentKey = namespaceSource_.getComponentKey()
+
+                    # Does the component already exist in the destination store?
+                    addressSource = namespaceSource_.getResolvedAddress()
+
+                    if dataExtensionPoint[sourceComponentKey]?
+                        throw new Error("The specified component already exists in the target store.")
+
 
                     return @createComponent(addressExtensionPoint_.createSubcomponentAddress());
 

--- a/src/onm-store.coffee
+++ b/src/onm-store.coffee
@@ -119,7 +119,7 @@ module.exports = class Store
 
             #
             # ============================================================================
-            @createComponent = (address_) =>
+            @createComponent = (address_, keyArray_, propertyAssignmentObject_) =>
                 try
                     if not (address_? and address_) then throw new Error("Missing address input parameter.");
                     if not @validateAddressModel(address_) then throw new Error("Address/store data model mismatch. Can't use the specified address to access this store.");
@@ -129,7 +129,7 @@ module.exports = class Store
                     if descriptor.namespaceType == "root" then throw new Error("The specified address refers to the root namespace of the store which is created automatically.");
 
                     # Creating the root namespace of a component automatically creates all its sub-namespaces as well.
-                    componentNamespace = new Namespace(@, address_, "new")
+                    componentNamespace = new Namespace(@, address_, "new", keyArray_, propertyAssignmentObject_)
                     return componentNamespace
 
                 catch exception

--- a/test/fixture/test-data.js
+++ b/test/fixture/test-data.js
@@ -13,8 +13,8 @@ var LUID = 1;
 
 var modelDeclaration = module.exports.modelDeclaration = {
     semanticBindings: {
-        setUniqueKey: function(data_) {
-            data_.key = "" + LUID++;
+        setUniqueKey: function(data_, key_) {
+            data_.key = (key_ != null) && key_ || ("" + LUID++);
         },
         getUniqueKey: function(data_) {
             return data_.key;

--- a/test/fixture/test-data.js
+++ b/test/fixture/test-data.js
@@ -94,6 +94,38 @@ var modelDeclaration = module.exports.modelDeclaration = {
                                 }
                             ]
                         }
+                    },
+                    {
+                        namespaceType: "extensionPoint",
+                        jsonTag: "phoneNumbers",
+                        componentArchetype: {
+                            namespaceType: "component",
+                            jsonTag: "phoneNumber",
+                            namespaceProperties: {
+                                userMutable: {
+                                    areaCode: {
+                                        defaultValue: ''
+                                    },
+                                    number: {
+                                        defaultValue: ''
+                                    }
+                                }
+                            },
+                            subNamespaces: [
+                                {
+                                    namespaceType: "child",
+                                    jsonTag: "notes",
+                                    namespaceProperties: {
+                                        userMutable: {
+                                            text: {
+                                                defaultValue: ''
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                                
+                        }
                     }
                 ]
             } // contact

--- a/test/test-onm.Address.visitChildAddresses.js
+++ b/test/test-onm.Address.visitChildAddresses.js
@@ -77,7 +77,7 @@ module.exports = describe("onm.Address.visitChildAddresses tests", function() {
         var actualResult = null;
         var expectedResult;
         before(function() {
-            expectedResult = '["addressBook.contacts.-.contact.emails","addressBook.contacts.-.contact.addresses"]';
+            expectedResult = '["addressBook.contacts.-.contact.emails","addressBook.contacts.-.contact.addresses","addressBook.contacts.-.contact.phoneNumbers"]';
             model = testData.createModel();
             address = model.createPathAddress("addressBook.contacts.contact");
             address.visitChildAddresses( function (addressChild_) {
@@ -98,7 +98,7 @@ module.exports = describe("onm.Address.visitChildAddresses tests", function() {
             var expectedResult;
 
             before(function() {
-                expectedResult = '["addressBook.contacts.-.contact.emails","addressBook.contacts.-.contact.addresses"]';
+                expectedResult = '["addressBook.contacts.1.contact.addresses.-.address.notes"]';
                 store = testData.createStore();
                 var namespace = store.createComponent(address);
                 addressContact = namespace.getResolvedAddress();

--- a/test/test-onm.Address.visitExtensionPointAddresses.js
+++ b/test/test-onm.Address.visitExtensionPointAddresses.js
@@ -74,7 +74,7 @@ module.exports = describe("onm.Address.visitExtensionPointAddresses tests", func
         var address;
         var extensionPointAddresses = [];
         var actualResult = "";
-        var expectedResult = '["addressBook.contacts.-.contact.emails","addressBook.contacts.-.contact.addresses"]';
+        var expectedResult = '["addressBook.contacts.-.contact.emails","addressBook.contacts.-.contact.addresses","addressBook.contacts.-.contact.phoneNumbers"]';
         before(function() {
             address = store.model.createPathAddress("addressBook.contacts.contact");
             address.visitExtensionPointAddresses(function(addressExtensionPoint_) {

--- a/test/test-onm.Store.createComponent.js
+++ b/test/test-onm.Store.createComponent.js
@@ -167,7 +167,7 @@ module.exports = describe("onm.Store.createComponent method tests", function() {
 
         describe("Serialize the test data store to JSON and compare the results against a known good snapshot.", function() {
 
-            var expectedJSON = '{"addressBook":{"properties":{"name":"","description":"","subproperties":{"collection":{}}},"contacts":{"1":{"firstName":"","lastName":"","key":"1","emails":{},"addresses":{},"phoneNumbers":{}},"2":{"firstName":"Joe","lastName":"Smith","key":"2","emails":{},"addresses":{},"phoneNumbers":{"3":{"areaCode":"000","number":"123-4567","key":"3","notes":{"text":"This is a note assigned via a hierarchical component construction options object."}}}},"test":{"firstName":"","lastName":"","key":"test","emails":{},"addresses":{},"phoneNumbers":{}},"JoeSmith":{"firstName":"","lastName":"","key":"JoeSmith","emails":{"primary":{"key":"primary"}},"addresses":{},"phoneNumbers":{}}}}}';
+            var expectedJSON = '{"addressBook":{"properties":{"name":"","description":"","subproperties":{"collection":{}}},"contacts":{"5":{"firstName":"","lastName":"","key":"5","emails":{},"addresses":{},"phoneNumbers":{}},"6":{"firstName":"Joe","lastName":"Smith","key":"6","emails":{},"addresses":{},"phoneNumbers":{"7":{"areaCode":"000","number":"123-4567","key":"7","notes":{"text":"This is a note assigned via a hierarchical component construction options object."}}}},"test":{"firstName":"","lastName":"","key":"test","emails":{},"addresses":{},"phoneNumbers":{}},"JoeSmith":{"firstName":"","lastName":"","key":"JoeSmith","emails":{"primary":{"key":"primary"}},"addresses":{},"phoneNumbers":{}}}}}';
 
             var actualJSON = null;
             before(function() {

--- a/test/test-onm.Store.createComponent.js
+++ b/test/test-onm.Store.createComponent.js
@@ -44,8 +44,10 @@ module.exports = describe("onm.Store.createComponent method tests", function() {
     });
 
     describe("Call onm.Store.createComponent to create a new 'contact'.", function() {
+
         var addressNewContact = null;
         var namespaceContact = null;
+
         before(function() {
             addressNewContact = addressRoot.createSubpathAddress("contacts.contact");
             namespaceContact  = store.createComponent(addressNewContact);

--- a/test/test-onm.Store.createComponent.js
+++ b/test/test-onm.Store.createComponent.js
@@ -59,6 +59,19 @@ module.exports = describe("onm.Store.createComponent method tests", function() {
             assert.instanceOf(namespaceContact, onm.Namespace);
         });
 
+        it("Verify the property values of the newly-created contact data component.", function() {
+            var dataContact = namespaceContact.data();
+            expect(dataContact).to.have.property('firstName').equal('');
+            expect(dataContact).to.have.property('lastName').equal('');
+            expect(dataContact).to.have.property('key');
+            expect(dataContact).to.have.property('emails');
+            expect(dataContact.emails).to.be.an('object');
+            expect(dataContact).to.have.property('addresses');
+            expect(dataContact.addresses).to.be.an('object');
+            expect(dataContact).to.have.property('phoneNumbers');
+            expect(dataContact.phoneNumbers).to.be.an('object');
+        });
+
         describe("Call onm.Store.createComponent with a single-key key array parameter.", function() {
             var keyArray = [ 'test' ];
             before(function() {
@@ -98,7 +111,7 @@ module.exports = describe("onm.Store.createComponent method tests", function() {
             });
         });
 
-        describe("Call onm.Store.createComponent with an optional construction options object.", function() {
+        describe("Call onm.Store.createComponent with a simple construction options object.", function() {
             var constructionOptions = {
                 firstName: "Joe",
                 lastName: "Smith"
@@ -108,14 +121,54 @@ module.exports = describe("onm.Store.createComponent method tests", function() {
                 namespace = store.createComponent(addressNewContact, null, constructionOptions);
             });
             it("A contact component should have been created.", function() {
-                assert.isDefined(namespaceContact);
-                assert.isNotNull(namespaceContact);
-                assert.instanceOf(namespaceContact, onm.Namespace);
+                assert.isDefined(namespace);
+                assert.isNotNull(namespace);
+                assert.instanceOf(namespace, onm.Namespace);
+            });
+            it("Verify the property values of the newly-created contact data component.", function() {
+                var dataContact = namespace.data();
+                expect(dataContact).to.have.property('firstName').equal('Joe');
+                expect(dataContact).to.have.property('lastName').equal('Smith');
+                expect(dataContact).to.have.property('key');
+                expect(dataContact).to.have.property('emails');
+                expect(dataContact.emails).to.be.an('object');
+                expect(dataContact).to.have.property('addresses');
+                expect(dataContact.addresses).to.be.an('object');
+                expect(dataContact).to.have.property('phoneNumbers');
+                expect(dataContact.phoneNumbers).to.be.an('object');
+            });
+
+            describe("Call onm.Store.createComponent with a hierarchical construction options object.", function() {
+                var addressNewPhoneNumber, namespacePhoneNumber;
+                var constructionOptions = {
+                    areaCode: '000',
+                    number: '123-4567',
+                    notes: {
+                        text: "This is a note assigned via a hierarchical component construction options object."
+                    }
+                };
+                before(function() {
+                    addressNewPhoneNumber = namespace.getResolvedAddress().createSubpathAddress("phoneNumbers.phoneNumber");
+                    namespacePhoneNumber = store.createComponent(addressNewPhoneNumber, null, constructionOptions);
+                });
+                it("A contact component should have been created.", function() {
+                    assert.isDefined(namespacePhoneNumber);
+                    assert.isNotNull(namespacePhoneNumber);
+                    assert.instanceOf(namespacePhoneNumber, onm.Namespace);
+                });
+                it("Verify the property values of the newly-created contact data component.", function() {
+                    var dataContact = namespacePhoneNumber.data();
+                    expect(dataContact).to.have.property('areaCode').equal('000');
+                    expect(dataContact).to.have.property('number').equal('123-4567');
+                    expect(dataContact).to.have.property('key');
+                });
             });
         });
 
         describe("Serialize the test data store to JSON and compare the results against a known good snapshot.", function() {
-            var expectedJSON = '{"addressBook":{"properties":{"name":"","description":"","subproperties":{"collection":{}}},"contacts":{"5":{"firstName":"","lastName":"","key":"5","emails":{},"addresses":{}},"test":{"firstName":"","lastName":"","key":"test","emails":{},"addresses":{}},"JoeSmith":{"firstName":"","lastName":"","key":"JoeSmith","emails":{"primary":{"key":"primary"}},"addresses":{}}}}}';
+
+            var expectedJSON = '{"addressBook":{"properties":{"name":"","description":"","subproperties":{"collection":{}}},"contacts":{"1":{"firstName":"","lastName":"","key":"1","emails":{},"addresses":{},"phoneNumbers":{}},"2":{"firstName":"Joe","lastName":"Smith","key":"2","emails":{},"addresses":{},"phoneNumbers":{"3":{"areaCode":"000","number":"123-4567","key":"3","notes":{"text":"This is a note assigned via a hierarchical component construction options object."}}}},"test":{"firstName":"","lastName":"","key":"test","emails":{},"addresses":{},"phoneNumbers":{}},"JoeSmith":{"firstName":"","lastName":"","key":"JoeSmith","emails":{"primary":{"key":"primary"}},"addresses":{},"phoneNumbers":{}}}}}';
+
             var actualJSON = null;
             before(function() {
                 actualJSON = store.toJSON();

--- a/test/test-onm.Store.createComponent.js
+++ b/test/test-onm.Store.createComponent.js
@@ -88,7 +88,7 @@ module.exports = describe("onm.Store.createComponent method tests", function() {
                 addressNewEmail = addressRoot.createSubpathAddress("contacts.contact.emails.email");
                 namespaceContact = store.createComponent(addressNewEmail, keyArray);
             });
-            it("We should be able to create a contact component.", function() {
+            it("A contact component should have been created.", function() {
                 assert.isDefined(namespaceContact);
                 assert.isNotNull(namespaceContact);
                 assert.instanceOf(namespaceContact, onm.Namespace);
@@ -96,7 +96,22 @@ module.exports = describe("onm.Store.createComponent method tests", function() {
             it("The component key of the newly-created component should be 'primary'.", function() {
                 assert.equal(namespaceContact.getComponentKey(), "primary");
             });
+        });
 
+        describe("Call onm.Store.createComponent with an optional construction options object.", function() {
+            var constructionOptions = {
+                firstName: "Joe",
+                lastName: "Smith"
+            };
+            var namespace = null;
+            before(function() {
+                namespace = store.createComponent(addressNewContact, null, constructionOptions);
+            });
+            it("A contact component should have been created.", function() {
+                assert.isDefined(namespaceContact);
+                assert.isNotNull(namespaceContact);
+                assert.instanceOf(namespaceContact, onm.Namespace);
+            });
         });
 
         describe("Serialize the test data store to JSON and compare the results against a known good snapshot.", function() {

--- a/test/test-onm.Store.createComponent.js
+++ b/test/test-onm.Store.createComponent.js
@@ -1,0 +1,74 @@
+// test-onm.Store.createComponent.js
+//
+
+var assert = require('chai').assert;
+var expect = require('chai').expect;
+var should = require('chai').should;
+var uuid = require('node-uuid');
+var onm = require('../onm');
+var testData = require('./fixture/test-data');
+
+module.exports = describe("onm.Store.createComponent method tests", function() {
+
+    var store = null;
+    var addressRoot = null;
+    var badDataModel = null;
+    var badAddress = null;
+
+    before(function() {
+        store = testData.createStore();
+        assert.isNotNull(store);
+        assert.instanceOf(store, onm.Store);
+        addressRoot = store.model.createRootAddress();
+        assert.isNotNull(addressRoot);
+        assert.instanceOf(addressRoot, onm.Address);
+        badDataModel = new onm.Model({ jsonTag: 'bogus' });
+        badAddress = badDataModel.createRootAddress();
+    });
+
+    it("Attempt to call onm.Store.createComponent with a null onm.Address parameter should throw.", function() {
+        assert.throws(function () { store.createComponent(); }, Error);
+    });
+
+    it("Attempt to call onm.Store.createComponent with an address of a non 'addressBook' data model should throw.", function() {
+        assert.throws(function () { store.createComponent(badAddress); }, Error);
+    });
+
+    it("Attempt to call onm.Store.createComponent with a qualified address should throw.", function() {
+        assert.throws(function() { store.createComponent(addressRoot); }, Error);
+    });
+
+    it("Attempt to call onm.Store.createComponent with a non-component address should throw.", function() {
+        var address = addressRoot.createSubpathAddress('properties.subproperties');
+        assert.throws(function() { store.createComponent(address); }, Error);
+    });
+
+    describe("Call onm.Store.createComponent to create a new 'contact'.", function() {
+        var addressNewContact = null;
+        var namespaceContact = null;
+        before(function() {
+            addressNewContact = addressRoot.createSubpathAddress("contacts.contact");
+            namespaceContact  = store.createComponent(addressNewContact);
+        });
+
+        it("We should be able to create a contact component.", function() {
+            assert.isDefined(namespaceContact);
+            assert.isNotNull(namespaceContact);
+            assert.instanceOf(namespaceContact, onm.Namespace);
+        });
+
+        describe("Call onm.Store.createComponent with a single-key key array parameter.", function() {
+            var keyArray = [ 'test' ];
+            before(function() {
+                namespaceContact = store.createComponent(addressNewContact, keyArray);
+            });
+            it("We should be able to create a contact component.", function() {
+                assert.isDefined(namespaceContact);
+                assert.isNotNull(namespaceContact);
+                assert.instanceOf(namespaceContact, onm.Namespace);
+            });
+        });
+
+    });
+});
+

--- a/test/test-onm.Store.createComponent.js
+++ b/test/test-onm.Store.createComponent.js
@@ -69,6 +69,45 @@ module.exports = describe("onm.Store.createComponent method tests", function() {
                 assert.isNotNull(namespaceContact);
                 assert.instanceOf(namespaceContact, onm.Namespace);
             });
+            it("The component key of the newly-created component should be 'test'.", function() {
+                assert.equal(namespaceContact.getComponentKey(), "test");
+            });
+        });
+
+        describe("Call onm.Store.createComponent with too many optional component override keys.", function() {
+            var keyArray = [ 'test', 'error' ];
+            it("The key array should be rejected because it is too long.", function() {
+                assert.throws(function() { store.createComponent(addressNewContact, keyArray); }, Error);
+            });
+        });
+
+        describe("Call onm.Store.createComponent with two optional override component keys.", function() {
+            var keyArray = [ 'JoeSmith', 'primary' ];
+            var addressNewEmail = null;
+            before(function() {
+                addressNewEmail = addressRoot.createSubpathAddress("contacts.contact.emails.email");
+                namespaceContact = store.createComponent(addressNewEmail, keyArray);
+            });
+            it("We should be able to create a contact component.", function() {
+                assert.isDefined(namespaceContact);
+                assert.isNotNull(namespaceContact);
+                assert.instanceOf(namespaceContact, onm.Namespace);
+            });
+            it("The component key of the newly-created component should be 'primary'.", function() {
+                assert.equal(namespaceContact.getComponentKey(), "primary");
+            });
+
+        });
+
+        describe("Serialize the test data store to JSON and compare the results against a known good snapshot.", function() {
+            var expectedJSON = '{"addressBook":{"properties":{"name":"","description":"","subproperties":{"collection":{}}},"contacts":{"5":{"firstName":"","lastName":"","key":"5","emails":{},"addresses":{}},"test":{"firstName":"","lastName":"","key":"test","emails":{},"addresses":{}},"JoeSmith":{"firstName":"","lastName":"","key":"JoeSmith","emails":{"primary":{"key":"primary"}},"addresses":{}}}}}';
+            var actualJSON = null;
+            before(function() {
+                actualJSON = store.toJSON();
+            });
+            it("The data store's JSON data should match the test's control JSON.", function() {
+                assert.equal(actualJSON, expectedJSON);
+            });
         });
 
     });

--- a/test/test-onm.Store.injectComponent.js
+++ b/test/test-onm.Store.injectComponent.js
@@ -1,0 +1,38 @@
+// test-onm.Store.injectComponent.js
+//
+
+var assert = require('chai').assert;
+var expect = require('chai').expect;
+var should = require('chai').should;
+
+var onm = require('../onm');
+
+var testData = require('./fixture/test-data');
+
+module.exports = describe("onm.Store.injectComponent method tests.", function() {
+
+    var model = null;
+    var store1 = null, store2 = null;
+    var namespaceContact = null;
+    var addressContacts = null;
+    before(function() {
+        model = testData.createModel();
+        store1 = testData.createStore();
+        store2 = testData.createStore();
+        addressContacts = model.createPathAddress("addressBook.contacts");
+        var addressNewContact = addressContacts.createSubpathAddress("contact");
+        namespaceContact = store1.createComponent(addressNewContact);
+        assert.instanceOf(model, onm.Model);
+        assert.instanceOf(store1, onm.Store);
+        assert.instanceOf(store2, onm.Store);
+        assert.instanceOf(namespaceContact, onm.Namespace);
+    });
+
+    it("We should be able to inject a copy of the contact from store1 into store2.", function() {
+
+        assert.instanceOf(store2.injectComponent(addressContacts, namespaceContact), onm.Namespace);
+
+    });
+
+});
+

--- a/test/test-onm.Store.injectComponent.js
+++ b/test/test-onm.Store.injectComponent.js
@@ -28,10 +28,16 @@ module.exports = describe("onm.Store.injectComponent method tests.", function() 
         assert.instanceOf(namespaceContact, onm.Namespace);
     });
 
+    it("We should not be able to inject a copy of the component over itself.", function() {
+        assert.throws(function() { store1.injectComponent(addressContacts, namespaceContact); }, Error);
+    });
+
     it("We should be able to inject a copy of the contact from store1 into store2.", function() {
-
         assert.instanceOf(store2.injectComponent(addressContacts, namespaceContact), onm.Namespace);
+    });
 
+    it("We should not be able to re-inject the contact from store1 into store2.", function() {
+        assert.throws(function() { store2.injectComponent(addressContacts, namespaceContact); }, Error);
     });
 
 });

--- a/test/test-onm.Store.js
+++ b/test/test-onm.Store.js
@@ -3,5 +3,6 @@
 
 module.exports = describe("onm.Store object method tests", function() {
     require('./test-onm.Store.openNamespace');
+    require('./test-onm.Store.injectComponent');
 });
 

--- a/test/test-onm.Store.js
+++ b/test/test-onm.Store.js
@@ -3,6 +3,7 @@
 
 module.exports = describe("onm.Store object method tests", function() {
     require('./test-onm.Store.openNamespace');
+    require('./test-onm.Store.createComponent');
     require('./test-onm.Store.injectComponent');
 });
 


### PR DESCRIPTION
For testing: a ton of work on onm.Store.createComponent to make it much, much simpler to work with external data sources.

You can now specify (a) optional component key array that is applied over the unresolved portions of the onm.Address passed to onm.Store.createComponent (b) optional, hierarhical data object to be cherry picked for construction property values overriding the default value, or programmatically-generated default from component's data model declaration.

The combination of these two additions makes it possible to write fairly terse and safe code to import object literals, and/or cherry-picked property values from a non-onm data source.
